### PR TITLE
Typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Migrate the posts contained in a Wordpress XML export file to Middleman-style ma
 ```
 git clone http://github.com/mdb/wp2middleman
 cd wp2middleman
-gem build wp2middlman.gemspec
+gem build wp2middleman.gemspec
 gem install wp2middleman-VERSION.gem
 ```
 


### PR DESCRIPTION
This fixes a tiny typo in the installation instructions. Thanks for the awesome tool!
