### PR TITLE
Include post_type and post_id optionally in the frontmatter; filter attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ tags: foo, bar
 
 ### Optional parameters
 
+* `--body_to_markdown true`: converts html content to markdown
+* `--include_post_id true`: includes the original Wordpress post_id in the frontmatter (may be useful for migrating)
+
+Example:
+
 ```
 wp2mm some_wordpress_export.xml --body_to_markdown true
 ```

--- a/lib/wp2middleman.rb
+++ b/lib/wp2middleman.rb
@@ -5,8 +5,8 @@ require 'wp2middleman/migrator'
 require 'wp2middleman/cli'
 
 module WP2Middleman
-  def self.migrate(wp_xml_export_file, body_to_markdown = false)
-    migrator = WP2Middleman::Migrator.new wp_xml_export_file, body_to_markdown: body_to_markdown
+  def self.migrate(wp_xml_export_file, body_to_markdown=false, include_post_id=false)
+    migrator = WP2Middleman::Migrator.new wp_xml_export_file, body_to_markdown: body_to_markdown, include_post_id: include_post_id
     migrator.migrate
   end
 end

--- a/lib/wp2middleman/cli.rb
+++ b/lib/wp2middleman/cli.rb
@@ -6,6 +6,8 @@ module WP2Middleman
 
     desc "WORDPRESS XML EXPORT FILE", "Migrate Wordpress posts to Middleman-style markdown files"
     option :body_to_markdown
+    option :include_post_id
+
     def wp2mm(wp_xml_export = nil)
       return usage unless wp_xml_export
 
@@ -14,7 +16,7 @@ module WP2Middleman
         exit 1
       end
 
-      WP2Middleman.migrate(wp_xml_export, options[:body_to_markdown])
+      WP2Middleman.migrate(wp_xml_export, options[:body_to_markdown], options[:include_post_id])
 
       say "Successfully migrated #{wp_xml_export}", "\033[32m"
     end

--- a/lib/wp2middleman/migrator.rb
+++ b/lib/wp2middleman/migrator.rb
@@ -3,8 +3,9 @@ module WP2Middleman
 
     attr_reader :posts
 
-    def initialize(wp_xml_export_file, body_to_markdown: false)
+    def initialize(wp_xml_export_file, body_to_markdown: false, include_post_id: false)
       @body_to_markdown = body_to_markdown
+      @include_post_id = include_post_id
       @posts = WP2Middleman::PostCollection.new(wp_xml_export_file).posts
     end
 
@@ -29,6 +30,14 @@ module WP2Middleman
       file_content += "title: '#{post.title}'\n"
       file_content += "date: #{post.date_published}\n"
       file_content += "tags: #{post.tags.join(', ')}\n"
+
+      if post.type != 'post'
+        file_content += "post_type: #{post.type}\n"
+      end
+
+      if @include_post_id
+        file_content += "post_id: #{post.id}\n"
+      end
 
       if !post.published?
         file_content += "published: false\n"

--- a/lib/wp2middleman/post.rb
+++ b/lib/wp2middleman/post.rb
@@ -8,6 +8,14 @@ module WP2Middleman
       @post = nokogiri_post_doc
     end
 
+    def id
+      post.xpath("wp:post_id").first.inner_text
+    end
+
+    def type
+      post.xpath("wp:post_type").first.inner_text
+    end
+
     def title
       post.css('title').text
     end


### PR DESCRIPTION
This is rather a heavy commit (so let me know if I should break it out) that does 3 things:
1. it provides a command line option `--include_post_id true` to include the original post_id in the frontmatter. This was necessary for me in migrating my old redirects
2. it adds a `post_type` method on the post migrator and includes the `post_type` in the frontmatter if `post_type != 'post'.` This is helpful for identifying old pages and custom post types from wordpress
3. it filters out `post_type == 'attachment'` which is how Wordpress manages images. The current behavior is to include those attachments as posts in the `export` directory, which is unexpected.

Thanks again. Feedback appreciated.
