### PR TITLE
Make it easier for people to build and install the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ Migrate the posts contained in a Wordpress XML export file to Middleman-style ma
 ```
 git clone http://github.com/mdb/wp2middleman
 cd wp2middleman
-gem build wp2middleman.gemspec
-gem install wp2middleman-VERSION.gem
+script/install
 ```
+
+If you get a `permission denied` message, set the correct permissions, then run `script/install` again:
+
+    chmod -R 755 script
 
 ## Commandline Usage
 

--- a/script/install
+++ b/script/install
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+echo "===> Building the wp2middleman gem locally"
+#gem build wp2middleman.gemspec
+
+# tail -1 grabs the last line in the output of "gem build ..."
+# which is "File: wp2middleman-0.0.1.gem"
+# awk then removes the "File: " part, which leaves us with the
+# full filename we can pass to "gem install"
+OUTPUT=$(gem build wp2middleman.gemspec | tail -1 | awk -F: '{print $NF}')
+
+echo "===> Installing the wp2middleman gem locally"
+gem install $OUTPUT


### PR DESCRIPTION
I added a shell script that runs the build and install in one step. If you merge this, ignore my first PR with the installation instructions in the README.
