### PR TITLE
Add newline between published: false and ---

### DIFF
--- a/lib/wp2middleman/migrator.rb
+++ b/lib/wp2middleman/migrator.rb
@@ -31,7 +31,7 @@ module WP2Middleman
       file_content += "tags: #{post.tags.join(', ')}\n"
 
       if !post.published?
-        file_content += "published: false"
+        file_content += "published: false\n"
       end
 
       file_content += "---\n\n"

--- a/spec/lib/wp2middleman/migrator_spec.rb
+++ b/spec/lib/wp2middleman/migrator_spec.rb
@@ -64,7 +64,7 @@ describe WP2Middleman::Migrator do
 
     context "the post is not published" do
       it "reports 'published: false' in the post's frontmatter" do
-        expect(migrator.file_content(migrator.posts[2])).to eq("---\ntitle: 'A third title: With colon'\ndate: 2011-07-26\ntags: some_tag, another tag, tag\npublished: false---\n\nFoo")
+        expect(migrator.file_content(migrator.posts[2])).to eq("---\ntitle: 'A third title: With colon'\ndate: 2011-07-26\ntags: some_tag, another tag, tag\npublished: false\n---\n\nFoo")
       end
     end
   end


### PR DESCRIPTION
Unpublished posts would result in something like this:

``` yml

---
title: Dale Howard - In Out (LT029, Side B1) (Snippet)
date: 2013-04-12
tags: fresh-tunes
published: false---
```

This commit fixes the formatting so it looks like this:

``` yml

---
title: Dale Howard - In Out (LT029, Side B1) (Snippet)
date: 2013-04-12
tags: fresh-tunes
published: false

---
```
