### PR TITLE
Add support for iframes when converting to markdown

### DIFF
--- a/lib/wp2middleman/post.rb
+++ b/lib/wp2middleman/post.rb
@@ -42,23 +42,11 @@ module WP2Middleman
       post.at_xpath(".//content:encoded").inner_text
     end
 
-    def sanitized_content
-      clean_content = content
-
-      clean_content.gsub!("<encoded>", " ")
-      clean_content.gsub!("</encoded>", " ")
-      clean_content.gsub!("&gt;", " ")
-      clean_content.gsub!("&lt;", " ")
-      clean_content.gsub("<![CDATA[", " ")
-      clean_content.gsub!("]];", " ")
-      clean_content.gsub!("]]>;", " ")
-
-      clean_content
-    end
-
     def markdown_content
       html = HTMLPage.new :contents => content
-
+      html.iframe do |node,_|
+        "#{node}"
+      end
       html.markdown
     end
 

--- a/spec/fixtures/fixture.xml
+++ b/spec/fixtures/fixture.xml
@@ -110,5 +110,36 @@
       <wp:meta_value><![CDATA[1]]></wp:meta_value>
     </wp:postmeta>
   </item>
+  <item>
+    <title>A fourth item with iframe content</title>
+    <link>http://someblog.com/?p=210</link>
+    <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+    <dc:creator>admin</dc:creator>
+    <guid isPermaLink="false">http://someblog.com/?p=209</guid>
+    <description></description>
+    <content:encoded><![CDATA[Here's a post with an iframe.
+
+<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F77999037&show_artwork=true"><a href="http://monfresh.com">Fresh Tunes</a></iframe>]]></content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+    <wp:post_id>210</wp:post_id>
+    <wp:post_date>2011-07-26 13:11:26</wp:post_date>
+    <wp:post_date_gmt>0000-00-00 00:00:00</wp:post_date_gmt>
+    <wp:comment_status>open</wp:comment_status>
+    <wp:ping_status>open</wp:ping_status>
+    <wp:post_name></wp:post_name>
+    <wp:status>private</wp:status>
+    <wp:post_parent>0</wp:post_parent>
+    <wp:menu_order>0</wp:menu_order>
+    <wp:post_type>post</wp:post_type>
+    <wp:post_password></wp:post_password>
+    <wp:is_sticky>0</wp:is_sticky>
+    <category domain="category" nicename="some_tag"><![CDATA[Some_tag]]></category>
+    <category domain="category" nicename="another tag"><![CDATA[Another Tag]]></category>
+    <category domain="post_tag" nicename="tag"><![CDATA[tag]]></category>
+    <wp:postmeta>
+      <wp:meta_key>_edit_last</wp:meta_key>
+      <wp:meta_value><![CDATA[1]]></wp:meta_value>
+    </wp:postmeta>
+  </item>
   </channel>
 </rss>

--- a/spec/lib/wp2middleman/migrator_spec.rb
+++ b/spec/lib/wp2middleman/migrator_spec.rb
@@ -22,7 +22,7 @@ describe WP2Middleman::Migrator do
     end
 
     it "writes a middleman markdown file for each post" do
-      migrator.should_receive(:write_file).exactly(3).times
+      migrator.should_receive(:write_file).exactly(4).times
       migrator.migrate
     end
   end
@@ -59,6 +59,10 @@ describe WP2Middleman::Migrator do
 
       it "formats the post body as markdown" do
         expect(migrator.file_content(migrator.posts[1])).to eq("---\ntitle: 'A second title'\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n---\n\n**Foo**")
+      end
+
+      it "includes iframe content" do
+        expect(migrator.file_content(migrator.posts[3])).to eq("---\ntitle: 'A fourth item with iframe content'\ndate: 2011-07-26\ntags: some_tag, another tag, tag\npublished: false\n---\n\nHere's a post with an iframe.\n\n\n<iframe width=\"100%\" height=\"166\" scrolling=\"no\" frameborder=\"no\" src=\"http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F77999037&amp;show_artwork=true\"><a href=\"http://monfresh.com\">Fresh Tunes</a></iframe>")
       end
     end
 

--- a/spec/lib/wp2middleman/post_spec.rb
+++ b/spec/lib/wp2middleman/post_spec.rb
@@ -71,12 +71,6 @@ describe WP2Middleman::Post do
     it { should eq "Paragraph one.\n\n      Paragraph two.\n    " }
   end
 
-  describe "#sanitized_content" do
-    subject { post_three.sanitized_content }
-
-    it { should eq "Foo" }
-  end
-
   describe "#markdown_content" do
     subject { post_two.markdown_content }
 

--- a/wp2middleman.gemspec
+++ b/wp2middleman.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "nokogiri"
-  spec.add_dependency "upmark"
   spec.add_dependency "html2markdown"
   spec.add_dependency "thor"
 


### PR DESCRIPTION
iframes were being stripped out of the markdown output. This includes them.
I also removed some unused dependencies (upmark) and methods (sanitized_content).
