### PR TITLE
More defensive yet forgiving rendering of frontmatter

### DIFF
--- a/lib/wp2middleman/migrator.rb
+++ b/lib/wp2middleman/migrator.rb
@@ -26,18 +26,32 @@ module WP2Middleman
 
     def file_content(post)
       file_content = "---\n"
-      file_content += "title: '#{post.title}'\n"
-      file_content += "date: #{post.date_published}\n"
-      file_content += "tags: #{post.tags.join(', ')}\n"
-
-      if !post.published?
-        file_content += "published: false\n"
-      end
-
+      file_content += formatted_frontmatter(post)
       file_content += "---\n\n"
       file_content += formatted_post_content(post)
 
       file_content
+    end
+
+    def format_string(string)
+      # if the string has special characters, quote it
+      if !string.match(/\A[[:alnum:] _]+\z/)
+        "'#{string}'"
+      else
+        string
+      end
+    end
+
+    def formatted_frontmatter(post)
+      frontmatter = "title: #{format_string(post.title)}\n"
+      frontmatter += "date: #{post.date_published}\n"
+      frontmatter += "tags: #{post.tags.map{|t| format_string(t)}.join(', ')}\n"
+
+      if !post.published?
+        frontmatter += "published: false\n"
+      end
+
+      frontmatter
     end
 
     def formatted_post_content(post)

--- a/spec/lib/wp2middleman/migrator_spec.rb
+++ b/spec/lib/wp2middleman/migrator_spec.rb
@@ -51,20 +51,56 @@ describe WP2Middleman::Migrator do
 
   describe "#file_content" do
     it "properly formats a post as a Middleman-style post" do
-      expect(migrator.file_content(migrator.posts[1])).to eq("---\ntitle: 'A second title'\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n---\n\n <strong>Foo</strong>")
+      expect(migrator.file_content(migrator.posts[1])).to eq("---\ntitle: A second title\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n---\n\n <strong>Foo</strong>")
     end
 
     context "its behavior if @body_to_markdown is true" do
       let(:migrator) { WP2Middleman::Migrator.new(file, body_to_markdown: true) }
 
       it "formats the post body as markdown" do
-        expect(migrator.file_content(migrator.posts[1])).to eq("---\ntitle: 'A second title'\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n---\n\n**Foo**")
+        expect(migrator.file_content(migrator.posts[1])).to eq("---\ntitle: A second title\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n---\n\n**Foo**")
       end
     end
 
     context "the post is not published" do
       it "reports 'published: false' in the post's frontmatter" do
         expect(migrator.file_content(migrator.posts[2])).to eq("---\ntitle: 'A third title: With colon'\ndate: 2011-07-26\ntags: some_tag, another tag, tag\npublished: false\n---\n\nFoo")
+      end
+    end
+  end
+
+  describe "#formatted_frontmatter" do
+    context "title has special characters" do
+      let(:post) {
+        double('Post',
+          :post_date => 'post_date',
+          :title => 'title, with, comma',
+          :date_published => '2011-07-25',
+          :tags => %w[some_tag another\ tag tag],
+          :published? => true,
+          :content => 'content'
+        )
+      }
+
+      it "wraps the title in quotes" do
+        expect(migrator.formatted_frontmatter(post)).to eq("title: 'title, with, comma'\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n")
+      end
+    end
+
+    context "title has no special characters" do
+      let(:post) {
+        double('Post',
+          :post_date => 'post_date',
+          :title => 'simple title',
+          :date_published => '2011-07-25',
+          :tags => %w[some_tag another\ tag tag],
+          :published? => true,
+          :content => 'content'
+        )
+      }
+
+      it "does not wrap the title in quotes" do
+        expect(migrator.formatted_frontmatter(post)).to eq("title: simple title\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n")
       end
     end
   end


### PR DESCRIPTION
This change tries to do a better job of detecting special characters in the frontmatter and only wraps the title (or individual tags) if they contain special characters.

Also, I tried using the `to_yaml` method (as mentioned in #5), but it was much, much too defensive and wrapped all the strings and date with quotes, and rendered tags as a multiline hyphened list (also not really what I wanted).
