### PR TITLE
Filter file attachments from exported posts

### DIFF
--- a/lib/wp2middleman/post.rb
+++ b/lib/wp2middleman/post.rb
@@ -34,6 +34,10 @@ module WP2Middleman
       post.xpath("wp:status").first.inner_text
     end
 
+    def type
+      post.xpath("wp:post_type").first.inner_text
+    end
+
     def published?
       status == 'publish'
     end

--- a/lib/wp2middleman/post_collection.rb
+++ b/lib/wp2middleman/post_collection.rb
@@ -7,7 +7,9 @@ module WP2Middleman
     end
 
     def posts
-      @xml.css('item').map { |post| WP2Middleman::Post.new(post) }
+      @xml.css('item')
+        .map { |post| WP2Middleman::Post.new(post) }
+        .reject { |post| post.type == 'attachment' }
     end
   end
 end

--- a/spec/fixtures/fixture.xml
+++ b/spec/fixtures/fixture.xml
@@ -141,5 +141,34 @@
       <wp:meta_value><![CDATA[1]]></wp:meta_value>
     </wp:postmeta>
   </item>
+   <item>
+    <title>an image</title>
+    <link>http://someblog.com/?attachment_id=280</link>
+    <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+    <dc:creator>admin</dc:creator>
+    <guid isPermaLink="false">http://someblog.com/wp-content/uploads/1970/01/an_image.png</guid>
+    <description></description>
+    <content:encoded><![CDATA[]]>Foo</content:encoded>
+    <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+    <wp:post_id>280</wp:post_id>
+    <wp:post_date>2011-07-26 13:11:26</wp:post_date>
+    <wp:post_date_gmt>0000-00-00 00:00:00</wp:post_date_gmt>
+    <wp:comment_status>open</wp:comment_status>
+    <wp:ping_status>open</wp:ping_status>
+    <wp:post_name></wp:post_name>
+    <wp:status>private</wp:status>
+    <wp:post_parent>0</wp:post_parent>
+    <wp:menu_order>0</wp:menu_order>
+    <wp:post_type>attachment</wp:post_type>
+    <wp:post_password></wp:post_password>
+    <wp:is_sticky>0</wp:is_sticky>
+    <category domain="category" nicename="some_tag"><![CDATA[Some_tag]]></category>
+    <category domain="category" nicename="another tag"><![CDATA[Another Tag]]></category>
+    <category domain="post_tag" nicename="tag"><![CDATA[tag]]></category>
+    <wp:postmeta>
+      <wp:meta_key>_edit_last</wp:meta_key>
+      <wp:meta_value><![CDATA[1]]></wp:meta_value>
+    </wp:postmeta>
+  </item>
   </channel>
 </rss>


### PR DESCRIPTION
This prevents file attachments (usually images) from being exported as posts. A component of #3 that has been isolated.
