### PR TITLE
Add support for comments

### DIFF
--- a/lib/wp2middleman/post.rb
+++ b/lib/wp2middleman/post.rb
@@ -44,6 +44,9 @@ module WP2Middleman
 
     def markdown_content
       html = HTMLPage.new :contents => content
+      html.comment do |node,_|
+        "#{node}"
+      end
       html.iframe do |node,_|
         "#{node}"
       end

--- a/spec/fixtures/fixture.xml
+++ b/spec/fixtures/fixture.xml
@@ -111,15 +111,17 @@
     </wp:postmeta>
   </item>
   <item>
-    <title>A fourth item with iframe content</title>
+    <title>A fourth item with iframe and comment</title>
     <link>http://someblog.com/?p=210</link>
     <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
     <dc:creator>admin</dc:creator>
     <guid isPermaLink="false">http://someblog.com/?p=209</guid>
     <description></description>
-    <content:encoded><![CDATA[Here's a post with an iframe.
+    <content:encoded><![CDATA[Here's a post with an iframe and a comment.
 
-<iframe width="100%" height="166" scrolling="no" frameborder="no" src="http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F77999037&show_artwork=true"><a href="http://monfresh.com">Fresh Tunes</a></iframe>]]></content:encoded>
+<!--more-->
+
+<iframe width="400" height="100" style="position: relative; display: block; width: 400px; height: 100px;" src="http://bandcamp.com/EmbeddedPlayer/v=2/track=833121761/size=venti/bgcol=FFFFFF/linkcol=4285BB/" allowtransparency="true" frameborder="0"><a href="http://dihannmoore.bandcamp.com/track/you-do-it-for-me">&quot;YOU DO IT FOR ME&quot; by DIHANN MOORE</a></iframe>]]></content:encoded>
     <excerpt:encoded><![CDATA[]]></excerpt:encoded>
     <wp:post_id>210</wp:post_id>
     <wp:post_date>2011-07-26 13:11:26</wp:post_date>

--- a/spec/lib/wp2middleman/migrator_spec.rb
+++ b/spec/lib/wp2middleman/migrator_spec.rb
@@ -61,8 +61,8 @@ describe WP2Middleman::Migrator do
         expect(migrator.file_content(migrator.posts[1])).to eq("---\ntitle: 'A second title'\ndate: 2011-07-25\ntags: some_tag, another tag, tag\n---\n\n**Foo**")
       end
 
-      it "includes iframe content" do
-        expect(migrator.file_content(migrator.posts[3])).to eq("---\ntitle: 'A fourth item with iframe content'\ndate: 2011-07-26\ntags: some_tag, another tag, tag\npublished: false\n---\n\nHere's a post with an iframe.\n\n\n<iframe width=\"100%\" height=\"166\" scrolling=\"no\" frameborder=\"no\" src=\"http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F77999037&amp;show_artwork=true\"><a href=\"http://monfresh.com\">Fresh Tunes</a></iframe>")
+      it "includes iframe and comment" do
+        expect(migrator.file_content(migrator.posts[3])).to eq("---\ntitle: 'A fourth item with iframe and comment'\ndate: 2011-07-26\ntags: some_tag, another tag, tag\npublished: false\n---\n\nHere's a post with an iframe and a comment.\n\n\n<!--more-->\n\n\n<iframe width=\"400\" height=\"100\" style=\"position: relative; display: block; width: 400px; height: 100px;\" src=\"http://bandcamp.com/EmbeddedPlayer/v=2/track=833121761/size=venti/bgcol=FFFFFF/linkcol=4285BB/\" allowtransparency=\"true\" frameborder=\"0\"><a href=\"http://dihannmoore.bandcamp.com/track/you-do-it-for-me\">\"YOU DO IT FOR ME\" by DIHANN MOORE</a></iframe>")
       end
     end
 


### PR DESCRIPTION
Some Wordpress posts use <!--more--> to specify where the excerpt should stop. This commit preserves those comments.
