### PR TITLE
Include arbitrary XML attributes in frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,14 @@ tags: foo, bar
 </ul>
 ```
 
-### Optional parameters
+## Optional Parameters
+
+```
+--body_to_markdown                         converts to markdown
+--include_fields=FIELD_ONE FIELD_TWO ETC   includes specific fields in frontmatter
+```
+
+### Convert to Markdown
 
 ```
 wp2mm some_wordpress_export.xml --body_to_markdown true
@@ -55,3 +62,28 @@ The post content in markdown or text, depending on how it was saved to Wordpress
 * list item
 * another list item
 ```
+
+### Include specific post fields
+
+```
+wp2mm some_wordpress_export.xml --include_fields wp:post_id link
+```
+
+Pulls the specified key/values out of the post xml and includes it in frontmatter:
+
+```
+---
+title: 'Some Title'
+date: YYYY-MM-DD
+tags: foo, bar
+wp:post_id: '280'
+link: http://somewebsite.com/2012/10/some-title
+---
+
+<p>The post content in HTML or text, depending on how it was saved to Wordpress.</p>
+<ul>
+<li>list item</li>
+<li>another list item</li>
+</ul>
+```
+

--- a/lib/wp2middleman.rb
+++ b/lib/wp2middleman.rb
@@ -5,8 +5,10 @@ require 'wp2middleman/migrator'
 require 'wp2middleman/cli'
 
 module WP2Middleman
-  def self.migrate(wp_xml_export_file, body_to_markdown = false)
-    migrator = WP2Middleman::Migrator.new wp_xml_export_file, body_to_markdown: body_to_markdown
+  def self.migrate(wp_xml_export_file, body_to_markdown = false, include_fields = [])
+    migrator = WP2Middleman::Migrator.new wp_xml_export_file,
+      body_to_markdown: body_to_markdown,
+      include_fields: include_fields
     migrator.migrate
   end
 end

--- a/lib/wp2middleman/cli.rb
+++ b/lib/wp2middleman/cli.rb
@@ -5,7 +5,9 @@ module WP2Middleman
     default_task :wp2mm
 
     desc "WORDPRESS XML EXPORT FILE", "Migrate Wordpress posts to Middleman-style markdown files"
-    option :body_to_markdown
+    option :body_to_markdown, :type => :boolean
+    option :include_fields, :type => :array
+
     def wp2mm(wp_xml_export = nil)
       return usage unless wp_xml_export
 
@@ -14,7 +16,8 @@ module WP2Middleman
         exit 1
       end
 
-      WP2Middleman.migrate(wp_xml_export, options[:body_to_markdown])
+      include_fields = options[:include_fields] || []
+      WP2Middleman.migrate(wp_xml_export, options[:body_to_markdown], include_fields)
 
       say "Successfully migrated #{wp_xml_export}", "\033[32m"
     end

--- a/lib/wp2middleman/migrator.rb
+++ b/lib/wp2middleman/migrator.rb
@@ -5,8 +5,9 @@ module WP2Middleman
 
     attr_reader :posts
 
-    def initialize(wp_xml_export_file, body_to_markdown: false)
+    def initialize(wp_xml_export_file, body_to_markdown: false, include_fields: [])
       @body_to_markdown = body_to_markdown
+      @include_fields = include_fields
       @posts = WP2Middleman::PostCollection.new(wp_xml_export_file).posts
     end
 
@@ -45,6 +46,10 @@ module WP2Middleman
       }
 
       data['published'] = false if !post.published?
+
+      @include_fields.each do |field|
+        data[field] = post.field(field)
+      end
 
       data
     end

--- a/lib/wp2middleman/post.rb
+++ b/lib/wp2middleman/post.rb
@@ -22,6 +22,10 @@ module WP2Middleman
       "#{date_published}-#{title_for_filename}"
     end
 
+    def field(field)
+      post.xpath(field).first.inner_text
+    end
+
     def post_date
       post.xpath("wp:post_date").first.inner_text
     end

--- a/spec/lib/wp2middleman/cli_spec.rb
+++ b/spec/lib/wp2middleman/cli_spec.rb
@@ -33,13 +33,28 @@ describe WP2Middleman::CLI do
       end
 
       it "migrates the posts listed in the XML file" do
-        WP2Middleman.should_receive(:migrate).with "foo", nil
+        WP2Middleman.should_receive(:migrate).with "foo", nil, []
         cli.wp2mm "foo"
       end
 
       it "reports that the directory has been successfully uploaded" do
         cli.should_receive(:say).with("Successfully migrated foo", "\e[32m")
         cli.wp2mm "foo"
+      end
+    end
+
+    context "sets include_fields" do
+      before :each do
+        WP2Middleman.stub(:migrate).and_return false
+        File.stub(:file?).and_return true
+      end
+
+      it "deserializes the values into an array" do
+        WP2Middleman.should_receive(:migrate).with "foo", nil, ['wp:post_id', 'guid']
+
+        capture :stdout do
+          WP2Middleman::CLI.start %w[wp2mm foo --include_fields=wp:post_id guid]
+        end
       end
     end
   end

--- a/spec/lib/wp2middleman/migrator_spec.rb
+++ b/spec/lib/wp2middleman/migrator_spec.rb
@@ -66,6 +66,15 @@ describe WP2Middleman::Migrator do
       end
     end
 
+    context "has been passed include_fields" do
+      let(:migrator) { WP2Middleman::Migrator.new(file, include_fields: ['wp:post_id']) }
+
+      it "includes the property and value from the item's xml in the frontmatter" do
+        expect(migrator.file_content(migrator.posts[1])).to eq("---\ntitle: A second title\ndate: '2011-07-25'\ntags:\n- some_tag\n- another tag\n- tag\nwp:post_id: '209'\n---\n\n <strong>Foo</strong>\n")
+      end
+
+    end
+
     context "the post is not published" do
       it "reports 'published: false' in the post's frontmatter" do
         expect(migrator.file_content(migrator.posts[2])).to eq("---\ntitle: 'A third title: With colon'\ndate: '2011-07-26'\ntags:\n- some_tag\n- another tag\n- tag\npublished: false\n---\n\nFoo\n")

--- a/spec/lib/wp2middleman/post_spec.rb
+++ b/spec/lib/wp2middleman/post_spec.rb
@@ -52,6 +52,12 @@ describe WP2Middleman::Post do
     it { should eq "private" }
   end
 
+  describe "#field" do
+    subject { post_one.field('wp:post_id') }
+
+    it { should eq "84" }
+  end
+
   describe "#published?" do
     subject { post_one.published? }
 

--- a/spec/lib/wp2middleman_spec.rb
+++ b/spec/lib/wp2middleman_spec.rb
@@ -11,7 +11,7 @@ describe WP2Middleman do
     end
 
     it "migrates the posts in the wordpress XML export file it's passed" do
-      WP2Middleman::Migrator.should_receive(:new).with('foo', body_to_markdown: false).and_return(@migrator_double)
+      WP2Middleman::Migrator.should_receive(:new).with('foo', body_to_markdown: false, include_fields: []).and_return(@migrator_double)
       @migrator_double.should_receive(:migrate)
 
       WP2Middleman.migrate 'foo'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,5 @@ SimpleCov.start
 require 'wp2middleman'
 
 RSpec.configure do |config|
-  # some (optional) config here
+  config.include CLIHelpers
 end

--- a/spec/support/cli_helpers.rb
+++ b/spec/support/cli_helpers.rb
@@ -1,0 +1,17 @@
+$0 = "wp2mm"
+ARGV.clear
+
+module CLIHelpers
+  def capture(stream)
+    begin
+      stream = stream.to_s
+      eval "$#{stream} = StringIO.new"
+      yield
+      result = eval("$#{stream}").string
+    ensure
+      eval("$#{stream} = #{stream.upcase}")
+    end
+
+    result
+  end
+end


### PR DESCRIPTION
This is a better implementation of #3 that provides a `--include_fields=FIELD_ONE FIELD_TWO etc...` CLI option that will pluck those attributes from the post XML and include them in the frontmatter.

FYI - This PR is based on the #14 branch, so if/once that gets merged, the changes will be clearer
