### PR TITLE
Include time in front matter date entry

### DIFF
--- a/lib/wp2middleman/frontmatter.rb
+++ b/lib/wp2middleman/frontmatter.rb
@@ -10,7 +10,7 @@ module WP2Middleman
     def post_data
       data = {
         'title' => post.title,
-        'date' => post.date_published,
+        'date' => post.date_time_published,
         'tags' => post.tags
       }
 

--- a/lib/wp2middleman/post.rb
+++ b/lib/wp2middleman/post.rb
@@ -32,6 +32,10 @@ module WP2Middleman
       Date.parse(post_date).to_s
     end
 
+    def date_time_published
+      Time.parse(post_date).strftime("%F %T")
+    end
+
     def status
       post.xpath("wp:status").first.inner_text
     end

--- a/lib/wp2middleman/post.rb
+++ b/lib/wp2middleman/post.rb
@@ -13,7 +13,7 @@ module WP2Middleman
     end
 
     def valid?
-      !(post_date.nil? || title.nil? || date_published.nil? || content.nil?)
+      !(post_date.nil? || title.nil? || date_time_published.nil? || content.nil?)
     end
 
     def attachment?

--- a/spec/lib/wp2middleman/frontmatter_spec.rb
+++ b/spec/lib/wp2middleman/frontmatter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe WP2Middleman::Migrator do
   def post(attributes = {})
-    defaults = {title: "mytitle", date_published: "mydate", tags: "mytags", published?: false}
+    defaults = {title: "mytitle", date_time_published: "mydate", tags: "mytags", published?: false}
     @post ||= double(defaults.merge attributes)
   end
 

--- a/spec/lib/wp2middleman/middleman_post_spec.rb
+++ b/spec/lib/wp2middleman/middleman_post_spec.rb
@@ -4,6 +4,7 @@ describe WP2Middleman::MiddlemanPost do
   let(:post_one) { double :post,
     title: "A Title",
     date_published: Date.new(2012,6,8).to_s,
+    date_time_published: Time.new(2012,6,8,10,11,12).strftime("%F %T"),
     content: "Paragraph one.\n\n      Paragraph two.\n    ",
     tags: [],
     published?: true
@@ -12,6 +13,7 @@ describe WP2Middleman::MiddlemanPost do
   let(:post_two) { double :post,
     title: "A second title",
     date_published: Date.new(2011,7,25).to_s,
+    date_time_published: Time.new(2011,7,25,1,2,3).strftime("%F %T"),
     content: " <strong>Foo</strong>",
     tags: ["some_tag", "another tag", "tag"],
     published?: true
@@ -20,6 +22,7 @@ describe WP2Middleman::MiddlemanPost do
   let(:post_three) { double :post,
     title: "A third title: With colon",
     date_published: Date.new(2011,7,26).to_s,
+    date_time_published: Time.new(2011,7,26,4,5,6).strftime("%F %T"),
     content: "Foo",
     tags: ["some_tag", "another tag", "tag"],
     published?: false
@@ -28,6 +31,7 @@ describe WP2Middleman::MiddlemanPost do
   let(:post_with_iframe) { double :post,
     title: "A fourth item with iframe and comment",
     date_published: Date.new(2011,7,26).to_s,
+    date_time_published: Time.new(2011,7,26,7,8,9).strftime("%F %T"),
     content: "Here's a post with an iframe and a comment.\n\n<!--more-->\n\n<iframe width=\"400\" height=\"100\" style=\"position: relative; display: block; width: 400px; height: 100px;\" src=\"http://bandcamp.com/EmbeddedPlayer/v=2/track=833121761/size=venti/bgcol=FFFFFF/linkcol=4285BB/\" allowtransparency=\"true\" frameborder=\"0\"><a href=\"http://dihannmoore.bandcamp.com/track/you-do-it-for-me\">&quot;YOU DO IT FOR ME&quot; by DIHANN MOORE</a></iframe>",
     tags: ["some_tag", "another tag", "tag"],
     published?: false
@@ -72,7 +76,7 @@ describe WP2Middleman::MiddlemanPost do
     post = WP2Middleman::MiddlemanPost.new post_one
 
     expect(post.file_content).to eq(
-      "---\ntitle: A Title\ndate: '2012-06-08'\ntags: []\n---\n\nParagraph one.\n\n      Paragraph two.\n    \n"
+      "---\ntitle: A Title\ndate: '2012-06-08 10:11:12'\ntags: []\n---\n\nParagraph one.\n\n      Paragraph two.\n    \n"
     )
   end
 
@@ -80,14 +84,14 @@ describe WP2Middleman::MiddlemanPost do
     post = WP2Middleman::MiddlemanPost.new post_two, body_to_markdown: true
 
     expect( post.file_content ).to eq(
-      "---\ntitle: A second title\ndate: '2011-07-25'\ntags:\n- some_tag\n- another tag\n- tag\n---\n\n**Foo**\n"
+      "---\ntitle: A second title\ndate: '2011-07-25 01:02:03'\ntags:\n- some_tag\n- another tag\n- tag\n---\n\n**Foo**\n"
     )
   end
 
   it "ignores iframe and comment tags when converting to markdown" do
     post = WP2Middleman::MiddlemanPost.new post_with_iframe, body_to_markdown: true
 
-    expect(post.file_content).to eq("---\ntitle: A fourth item with iframe and comment\ndate: '2011-07-26'\ntags:\n- some_tag\n- another tag\n- tag\npublished: false\n---\n\nHere's a post with an iframe and a comment.\n\n\n<!--more-->\n\n\n<iframe width=\"400\" height=\"100\" style=\"position: relative; display: block; width: 400px; height: 100px;\" src=\"http://bandcamp.com/EmbeddedPlayer/v=2/track=833121761/size=venti/bgcol=FFFFFF/linkcol=4285BB/\" allowtransparency=\"true\" frameborder=\"0\"><a href=\"http://dihannmoore.bandcamp.com/track/you-do-it-for-me\">\"YOU DO IT FOR ME\" by DIHANN MOORE</a></iframe>\n")
+    expect(post.file_content).to eq("---\ntitle: A fourth item with iframe and comment\ndate: '2011-07-26 07:08:09'\ntags:\n- some_tag\n- another tag\n- tag\npublished: false\n---\n\nHere's a post with an iframe and a comment.\n\n\n<!--more-->\n\n\n<iframe width=\"400\" height=\"100\" style=\"position: relative; display: block; width: 400px; height: 100px;\" src=\"http://bandcamp.com/EmbeddedPlayer/v=2/track=833121761/size=venti/bgcol=FFFFFF/linkcol=4285BB/\" allowtransparency=\"true\" frameborder=\"0\"><a href=\"http://dihannmoore.bandcamp.com/track/you-do-it-for-me\">\"YOU DO IT FOR ME\" by DIHANN MOORE</a></iframe>\n")
   end
 
   it "appends included fields in with frontmatter" do
@@ -95,7 +99,7 @@ describe WP2Middleman::MiddlemanPost do
     post = WP2Middleman::MiddlemanPost.new post_two, include_fields: ['wp:post_id']
 
     expect( post.file_content ).to eq(
-      "---\ntitle: A second title\ndate: '2011-07-25'\ntags:\n- some_tag\n- another tag\n- tag\nwp:post_id: '209'\n---\n\n <strong>Foo</strong>\n"
+      "---\ntitle: A second title\ndate: '2011-07-25 01:02:03'\ntags:\n- some_tag\n- another tag\n- tag\nwp:post_id: '209'\n---\n\n <strong>Foo</strong>\n"
     )
   end
 
@@ -103,7 +107,7 @@ describe WP2Middleman::MiddlemanPost do
     post = WP2Middleman::MiddlemanPost.new post_three
 
     expect( post.file_content ).to eq(
-      "---\ntitle: 'A third title: With colon'\ndate: '2011-07-26'\ntags:\n- some_tag\n- another tag\n- tag\npublished: false\n---\n\nFoo\n"
+      "---\ntitle: 'A third title: With colon'\ndate: '2011-07-26 04:05:06'\ntags:\n- some_tag\n- another tag\n- tag\npublished: false\n---\n\nFoo\n"
     )
   end
 

--- a/spec/lib/wp2middleman/post_spec.rb
+++ b/spec/lib/wp2middleman/post_spec.rb
@@ -28,6 +28,12 @@ describe WP2Middleman::Post do
     it { is_expected.to eq "2012-06-08" }
   end
 
+  describe "#date_time_published" do
+    subject { post_one.date_time_published }
+
+    it { is_expected.to eq "2012-06-08 03:21:41" }
+  end
+
   describe "#status" do
     subject { post_three.status }
 
@@ -72,12 +78,12 @@ describe WP2Middleman::Post do
   end
 
   describe "#valid?" do
-    def post(post_date: Date.new(2014,2,19), title: "Title", date_published: Date.new(2014,2,19), content: "content")
+    def post(post_date: Date.new(2014,2,19), title: "Title", date_time_published: Time.new(2014,2,19,1,2,3), content: "content")
       post = WP2Middleman::Post.new(double)
 
       allow(post).to receive(:post_date) { post_date }
       allow(post).to receive(:title) { title }
-      allow(post).to receive(:date_published) { date_published }
+      allow(post).to receive(:date_time_published) { date_time_published }
       allow(post).to receive(:content) { content }
 
       post
@@ -96,7 +102,7 @@ describe WP2Middleman::Post do
     end
 
     it "is not valid without a date_published" do
-      expect(post(date_published: nil)).to_not be_valid
+      expect(post(date_time_published: nil)).to_not be_valid
     end
 
     it "is not valid without content" do


### PR DESCRIPTION
Thanks for the super-handy tool!

This PR sets the front matter `date` entry to the date and time of publication--rather than just the date--which allows multiple posts in the same day to maintain their order.
